### PR TITLE
Use ULID as the packet identifier

### DIFF
--- a/lollipopd/Makefile
+++ b/lollipopd/Makefile
@@ -1,7 +1,7 @@
 all: lollipopd
 
-lollipopd: main.c
-	cc -o lollipopd main.c
+lollipopd: main.c ulid.c ulid.h
+	cc -o lollipopd main.c ulid.c
 
 .PHONY: clean
 clean:

--- a/lollipopd/main.c
+++ b/lollipopd/main.c
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "ulid.h"
+
 #define MAX(a, b)	((a) > (b) ? (a) : (b))
 #define SUNPATHLEN	sizeof(((struct sockaddr_un *)0)->sun_path)
 #define BACKLOG	5
@@ -40,12 +42,12 @@ static void usage(void);
 int
 main(int argc, char *argv[])
 {
-	struct timeval tv;
+	struct ulid ul;
 	fd_set rfds;
 	ssize_t bytes;
 	int c, fd, nfds, rxfd, sockfd, spoolfd, tunfd;
 	char filepath[PATH_MAX], sockpath[PATH_MAX], spoolpath[PATH_MAX];
-	char buf[2048], ifname[IFNAMSIZ];
+	char buf[2048], identifier[27], ifname[IFNAMSIZ];
 
 	(void)strncpy(ifname, IFNAME, sizeof(ifname));
 	(void)strncpy(sockpath, SOCKPATH, sizeof(sockpath));
@@ -93,11 +95,11 @@ main(int argc, char *argv[])
 		if (bytes == -1)
 			err(1, "read");
 
-		if (gettimeofday(&tv, NULL) == -1)
-			err(1, "gettimeofday");
+		if (generate_ulid(&ul) == -1)
+			err(1, "generate_ulid");
+		unparse_ulid(identifier, &ul);
 		(void)snprintf(filepath, sizeof(filepath),
-				"%s.%d.%jd.%06jd", ifname, nPacket,
-				(intmax_t)tv.tv_sec, (intmax_t)tv.tv_usec);
+				"%s.%s", ifname, identifier);
 		(void)fprintf(stderr, "%s -> %s",
 				FD_ISSET(sockfd, &rfds) ? sockpath : ifname,
 				FD_ISSET(sockfd, &rfds) ? ifname : filepath);

--- a/lollipopd/ulid.c
+++ b/lollipopd/ulid.c
@@ -1,0 +1,53 @@
+#include <sys/random.h>
+#include <sys/time.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ulid.h"
+
+int
+generate_ulid(struct ulid *ul)
+{
+	struct timeval tv;
+	uint_least64_t msec;
+	size_t i;
+
+	if (gettimeofday(&tv, NULL) == -1)
+		return -1;
+
+	msec = (uint_least64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+	for (i = sizeof(ul->ul_time); i-- > 0; ) {
+		ul->ul_time[i] = msec & 0xFF;
+		msec >>= 8;
+	}
+
+	if (getrandom(ul->ul_rand, sizeof(ul->ul_rand), GRND_NONBLOCK) == -1)
+		return -1;
+
+	return 0;
+}
+
+void
+unparse_ulid(char *out, const struct ulid *ul)
+{
+	const char *ctab = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+	size_t i, j, offset;
+	uint_least16_t tmp;
+	uint8_t buf[16];
+
+	(void)memcpy(buf, ul, sizeof(buf));
+	offset = 0;
+	tmp = 0;
+	for (i = 26, j = 16; i-- > 0; ) {
+		if (offset < 8) {
+			tmp |= buf[--j] << offset;
+			offset += 8;
+		}
+		out[i] = ctab[tmp & 0x1F];
+		offset -= 5;
+		tmp >>= 5;
+	}
+	out[26] = '\0';
+}

--- a/lollipopd/ulid.h
+++ b/lollipopd/ulid.h
@@ -1,0 +1,14 @@
+#ifndef ULID_H
+#define ULID_H
+
+#include <stdint.h>
+
+struct ulid {
+	uint8_t ul_time[6];
+	uint8_t ul_rand[10];
+} __attribute__((__packed__));
+
+int generate_ulid(struct ulid *ul);
+void unparse_ulid(char *out, const struct ulid *ul);
+
+#endif	/* !ULID_H */


### PR DESCRIPTION
This commit resolves #3.

```console
$ sudo ./lollipopd 
post0 -> post0.01K80TMVHHFYW2QWA2BVPEFAKH
00000	60 00 00 00 00 08 3a ff fe 80 00 00 00 00 00 00 
00010	dd e8 8a 79 9a 87 c0 64 ff 02 00 00 00 00 00 00 
00020	00 00 00 00 00 00 00 02 85 00 b9 e8 00 00 00 00 
00030
post0 -> post0.01K80TMZDNEE6ZMVHF41VESHDE
00000	60 00 00 00 00 08 3a ff fe 80 00 00 00 00 00 00 
00010	dd e8 8a 79 9a 87 c0 64 ff 02 00 00 00 00 00 00 
00020	00 00 00 00 00 00 00 02 85 00 b9 e8 00 00 00 00 
00030
^C
```