### PR TITLE
Packets awaiting transmission are placed in `waiting` directory

### DIFF
--- a/lollipopd/main.c
+++ b/lollipopd/main.c
@@ -30,7 +30,7 @@
 
 #define IFNAME		"post%d"
 #define SOCKPATH	"/var/run/lollipop.%s.socket"
-#define SPOOLPATH	"/var/spool/lollipop/"
+#define SPOOLPATH	"/var/spool/lollipop/waiting/"
 #define TUNTAPPATH	"/dev/net/tun"
 
 static int nPacket;


### PR DESCRIPTION
This commit resolves #4, for now.