### PR TITLE
Update Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: $(LOLLIPOPD) $(LOLLIPOP)
 $(LOLLIPOPD) $(LOLLIPOP):
 	$(MAKE) -C $@
 
-.PHONY: clean
-clean:
+.PHONY: clean install
+install clean:
 	$(MAKE) -C $(LOLLIPOPD) $@
 	$(MAKE) -C $(LOLLIPOP) $@

--- a/lollipop/Makefile
+++ b/lollipop/Makefile
@@ -6,6 +6,6 @@ all: $(COMMANDS)
 $(COMMANDS):
 	$(MAKE) -C $@
 
-.PHONY: clean
-clean:
+.PHONY: clean install
+install clean:
 	for c in $(COMMANDS); do $(MAKE) -C $$c $@; done

--- a/lollipop/in/Makefile
+++ b/lollipop/in/Makefile
@@ -4,6 +4,9 @@ OBJS=	./main.o
 CC=	gcc
 CFLAGS=	-I../../include -O2
 
+PREFIX=	/usr/local
+SPOOL=	/var/spool
+
 .PHONY: all
 all: $(TARGET)
 
@@ -13,3 +16,11 @@ $(TARGET): $(OBJS)
 .PHONY: clean
 clean:
 	$(RM) $(TARGET) $(OBJS)
+
+.PHONY: install
+install: $(TARGET)
+	install $(TARGET) $(PREFIX)/sbin/.
+	mkdir -p $(SPOOL)/lollipop/waiting
+	mkdir -p $(SPOOL)/lollipop/sending
+	mkdir -p $(SPOOL)/lollipop/sent
+	mkdir -p $(SPOOL)/lollipop/removed

--- a/lollipop/ls/Makefile
+++ b/lollipop/ls/Makefile
@@ -4,6 +4,9 @@ OBJS=	./main.o
 CC=	gcc
 CFLAGS=	-I../../include -O2
 
+PREFIX=	/usr/local
+SPOOL=	/var/spool
+
 .PHONY: all
 all: $(TARGET)
 
@@ -13,3 +16,11 @@ $(TARGET): $(OBJS)
 .PHONY: clean
 clean:
 	$(RM) $(TARGET) $(OBJS)
+
+.PHONY: install
+install: $(TARGET)
+	install $(TARGET) $(PREFIX)/sbin/.
+	mkdir -p $(SPOOL)/lollipop/waiting
+	mkdir -p $(SPOOL)/lollipop/sending
+	mkdir -p $(SPOOL)/lollipop/sent
+	mkdir -p $(SPOOL)/lollipop/removed

--- a/lollipop/out/Makefile
+++ b/lollipop/out/Makefile
@@ -4,6 +4,9 @@ OBJS=	./main.o
 CC=	gcc
 CFLAGS=	-I../../include -O2
 
+PREFIX=	/usr/local
+SPOOL=	/var/spool
+
 .PHONY: all
 all: $(TARGET)
 
@@ -13,3 +16,11 @@ $(TARGET): $(OBJS)
 .PHONY: clean
 clean:
 	$(RM) $(TARGET) $(OBJS)
+
+.PHONY: install
+install: $(TARGET)
+	install $(TARGET) $(PREFIX)/sbin/.
+	mkdir -p $(SPOOL)/lollipop/waiting
+	mkdir -p $(SPOOL)/lollipop/sending
+	mkdir -p $(SPOOL)/lollipop/sent
+	mkdir -p $(SPOOL)/lollipop/removed

--- a/lollipop/rm/Makefile
+++ b/lollipop/rm/Makefile
@@ -4,6 +4,9 @@ OBJS=	./main.o
 CC=	gcc
 CFLAGS=	-I../../include -O2
 
+PREFIX=	/usr/local
+SPOOL=	/var/spool
+
 .PHONY: all
 all: $(TARGET)
 
@@ -13,3 +16,11 @@ $(TARGET): $(OBJS)
 .PHONY: clean
 clean:
 	$(RM) $(TARGET) $(OBJS)
+
+.PHONY: install
+install: $(TARGET)
+	install $(TARGET) $(PREFIX)/sbin/.
+	mkdir -p $(SPOOL)/lollipop/waiting
+	mkdir -p $(SPOOL)/lollipop/sending
+	mkdir -p $(SPOOL)/lollipop/sent
+	mkdir -p $(SPOOL)/lollipop/removed

--- a/lollipopd/Makefile
+++ b/lollipopd/Makefile
@@ -4,6 +4,9 @@ OBJS=	./main.o ../common/ulid.o
 CC=	gcc
 CFLAGS=	-I ../include -O2
 
+PREFIX=	/usr/local
+SPOOL=	/var/spool
+
 .PHONY: all
 all: $(TARGET)
 
@@ -13,3 +16,11 @@ $(TARGET): $(OBJS)
 .PHONY: clean
 clean:
 	$(RM) $(TARGET) $(OBJS)
+
+.PHONY: install
+install: $(TARGET)
+	install $(TARGET) $(PREFIX)/sbin/.
+	mkdir -p $(SPOOL)/lollipop/waiting
+	mkdir -p $(SPOOL)/lollipop/sending
+	mkdir -p $(SPOOL)/lollipop/sent
+	mkdir -p $(SPOOL)/lollipop/removed


### PR DESCRIPTION
This PR resolves #12.

次の編集が含まれます:

- make clean はプロジェクト全体を clean するためにプロジェクトのルートで実行できるようになりました。
- 将来的な include の追加に備え、全てのプログラムをビルドする Makefile に -I を記述しました。
- make install によってシステムに LoLLIPoP システムをインストールできるようになりました。
    - スプーリングのためのディレクトリも作成されます。
    - しかし、これは暫定的です。権限周りはデフォルトのままですし、デフォルトの場所から変更しようとすると不便かもしれません。
    - もっとも、autoconf のようなものを利用することも検討すべきかもしれません。

ひとまず動いていると思われますから、PR を立てます。