### PR TITLE
Search for packets using a backward match

### DIFF
--- a/common/match.c
+++ b/common/match.c
@@ -1,0 +1,14 @@
+#include <string.h>
+
+#include "match.h"
+
+int
+ends_with(const char *s, const char *t)
+{
+	size_t ls, lt;
+
+	ls = strlen(s);
+	lt = strlen(t);
+
+	return lt <= ls && memcmp(s+ls-lt, t, lt) == 0;
+}

--- a/include/match.h
+++ b/include/match.h
@@ -1,0 +1,6 @@
+#ifndef MATCH_H
+#define MATCH_H
+
+int ends_with(const char *s, const char *t);
+
+#endif	/* !MATCH_H */

--- a/lollipop/out/Makefile
+++ b/lollipop/out/Makefile
@@ -1,5 +1,5 @@
 TARGET=	lollipop-out
-OBJS=	./main.o
+OBJS=	./main.o ../../common/match.o
 
 CC=	gcc
 CFLAGS=	-I../../include -O2

--- a/lollipop/out/main.c
+++ b/lollipop/out/main.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "match.h"
 #include "path.h"
 
 static void usage(FILE *fp);
@@ -107,7 +108,7 @@ search_packet(char *path, size_t pathlen, const char *identifier)
 		return -1;
 
 	while (errno = 0, (d = readdir(dirp)) != NULL)
-		if (strstr(d->d_name, identifier) != NULL) {
+		if (ends_with(d->d_name, identifier)) {
 			strncpy(path, d->d_name, pathlen);
 			path[pathlen-1] = '\0';
 			(void)closedir(dirp);

--- a/lollipop/rm/Makefile
+++ b/lollipop/rm/Makefile
@@ -1,5 +1,5 @@
 TARGET=	lollipop-rm
-OBJS=	./main.o
+OBJS=	./main.o ../../common/match.o
 
 CC=	gcc
 CFLAGS=	-I../../include -O2

--- a/lollipop/rm/main.c
+++ b/lollipop/rm/main.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "match.h"
 #include "path.h"
 
 static void usage(FILE *fp);
@@ -84,7 +85,7 @@ search_packet(char *path, size_t pathlen, const char *identifier)
 		return -1;
 
 	while (errno = 0, (d = readdir(dirp)) != NULL)
-		if (strstr(d->d_name, identifier) != NULL) {
+		if (ends_with(d->d_name, identifier)) {
 			strncpy(path, d->d_name, pathlen);
 			path[pathlen-1] = '\0';
 			(void)closedir(dirp);


### PR DESCRIPTION
This commit resolves #18.

パケットの検索方法を（場所を問わない）部分一致から後方一致に変更します。

これはある種の破壊的変更ですが、この挙動を利用している LoLLIPoP tool chain のフロントエンドは存在しないと思われるので、影響は少ないと考えています。